### PR TITLE
Add AUR package to Install Guide

### DIFF
--- a/wiki/Buddy-installation-guide.md
+++ b/wiki/Buddy-installation-guide.md
@@ -29,7 +29,22 @@ Enable autostart by clicking on the icon (right-click) and selecting the followi
 
 ![startup-option](images/startup-option-win.png)
 
-## Linux
+## Arch Linux
+
+### Step 1
+Install the [moondeckbuddy-appimage](https://aur.archlinux.org/packages/moondeckbuddy-appimage) through the Arch User Repository (AUR).
+
+### Step 2
+
+Start MoonDeckBuddy or MoonDeckStream from the CLI with:
+```
+$ moondeckbuddy
+$ moondeckstream
+```
+
+Continue [Step 3](### Step 3) in Linux install below.
+
+## Linux Other (AppImage)
 
 ### Step 1
 

--- a/wiki/Buddy-installation-guide.md
+++ b/wiki/Buddy-installation-guide.md
@@ -42,7 +42,7 @@ $ moondeckbuddy
 $ moondeckstream
 ```
 
-Continue [Step 3](### Step 3) in Linux install below.
+Continue [Step 3](#step-3-1) in Linux install below.
 
 ## Linux Other (AppImage)
 

--- a/wiki/Sunshine-setup.md
+++ b/wiki/Sunshine-setup.md
@@ -6,6 +6,7 @@ All you have to do is to add a new app with the following:
 * "**Command**" field set to the `MoonDeckStream` executable, using the installation folder created during Moondeck Buddy's setup.
   * On Windows, the default should be `<BuddyInstallDirectory>\bin\MoonDeckStream.exe` (replace `<BuddyInstallDirectory>` with the file path of where it is installed).
   * On Linux, it depends on the earlier setup, but it can be as simple as `/home/frog/Downloads/MoonDeckBuddy.AppImage --exec MoonDeckStream`.
+  * If using Arch Linux AUR package set command to `moondeckstream`
 * "**Continue streaming...**" - just disable the checkbox.
 
 Bellow an example of the required settings using a non-standard installation path:

--- a/wiki/Sunshine-setup.md
+++ b/wiki/Sunshine-setup.md
@@ -44,7 +44,7 @@ namespace Sunshine
             keybd_event(VK_ALT, 0, KEYEVENTF_EXTENDEDKEY, 0);
             keybd_event(VK_LWIN, 0, KEYEVENTF_EXTENDEDKEY, 0);
             keybd_event(VK_B, 0, KEYEVENTF_EXTENDEDKEY, 0);
-            
+
             // Release the keyboard shortcut
             keybd_event(VK_B, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
             keybd_event(VK_LWIN, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
@@ -87,4 +87,3 @@ By default, almost every application uses the default display when starting up. 
 ![image](images/sunshine-nircmd.png)
 4. You **might** also want to change Steam's Big Picture preferred display if it starts elsewhere ignoring the step 3.
 ![image](images/sunshine-bigpicture.png)
-

--- a/wiki/Sunshine-setup.md
+++ b/wiki/Sunshine-setup.md
@@ -6,7 +6,7 @@ All you have to do is to add a new app with the following:
 * "**Command**" field set to the `MoonDeckStream` executable, using the installation folder created during Moondeck Buddy's setup.
   * On Windows, the default should be `<BuddyInstallDirectory>\bin\MoonDeckStream.exe` (replace `<BuddyInstallDirectory>` with the file path of where it is installed).
   * On Linux, it depends on the earlier setup, but it can be as simple as `/home/frog/Downloads/MoonDeckBuddy.AppImage --exec MoonDeckStream`.
-  * If using Arch Linux AUR package set command to `moondeckstream`
+  * If using Arch Linux AUR package set command to `moondeckstream`.
 * "**Continue streaming...**" - just disable the checkbox.
 
 Bellow an example of the required settings using a non-standard installation path:


### PR DESCRIPTION
I created an AUR pkg for easy install on Arch Linux. Updated the installation documentation to reference installation resources. 
[moondeckbuddy-appimage](https://aur.archlinux.org/packages/moondeckbuddy-appimage)