### PR TITLE
Fix symlinks for Buddy and Stream

### DIFF
--- a/wiki/Buddy-installation-guide.md
+++ b/wiki/Buddy-installation-guide.md
@@ -38,8 +38,8 @@ Install the [moondeckbuddy-appimage](https://aur.archlinux.org/packages/moondeck
 
 Start MoonDeckBuddy or MoonDeckStream from the CLI with:
 ```
-$ moondeckbuddy
-$ moondeckstream
+$ MoonDeckBuddy
+$ MoonDeckStream
 ```
 
 Continue [Step 3](#step-3-1) in Linux install below.

--- a/wiki/Sunshine-setup.md
+++ b/wiki/Sunshine-setup.md
@@ -6,7 +6,6 @@ All you have to do is to add a new app with the following:
 * "**Command**" field set to the `MoonDeckStream` executable, using the installation folder created during Moondeck Buddy's setup.
   * On Windows, the default should be `<BuddyInstallDirectory>\bin\MoonDeckStream.exe` (replace `<BuddyInstallDirectory>` with the file path of where it is installed).
   * On Linux, it depends on the earlier setup, but it can be as simple as `/home/frog/Downloads/MoonDeckBuddy.AppImage --exec MoonDeckStream`.
-  * If using Arch Linux AUR package set command to `moondeckstream`.
 * "**Continue streaming...**" - just disable the checkbox.
 
 Bellow an example of the required settings using a non-standard installation path:


### PR DESCRIPTION
I made a bad assumption with the symlinks, using lower case.
This update matches pkgrel-2 in AUR using the same CamelCase commands as mentioned in the current configuration guidance  