### PR TITLE
Docs/linux updates

### DIFF
--- a/wiki/Buddy-configuration.md
+++ b/wiki/Buddy-configuration.md
@@ -49,7 +49,7 @@ Resolution change not supported yet as the [API](https://wayland.app/protocols/w
  2. Set sunshine *DO* `kscreen-doctor output.X1.mode.Y1` to the desired client streaming resolution.
  3. Set sunshine *UNDO* `kscreen-doctor output.X2.mode.Y2` back to the original resolution.
 
-#### Linux Idle
+#### Linux Inhibit Sleep and Idle
 
 If a game is paused or input is delayed within the idle time limit, power savings can put the monitor to sleep or suspend the system. This can cause issues when trying to resume a game at a later time. You can use systemd-inhibit in order to enforce the system will stay awake, while MoonDeckStream is active. Prepend the following to the *Command* in the Sunshine MoonDeckStream configuration.
 

--- a/wiki/Buddy-configuration.md
+++ b/wiki/Buddy-configuration.md
@@ -41,13 +41,7 @@ Note: in the Buddy's configuration the screen is referred to as a display due to
 
 Resolution change not supported yet as the [API](https://wayland.app/protocols/wlr-output-management-unstable-v1) is not mature enough and the compositor support is lacking.
 
-*Note:* Although we cannot change the resolution through sunshine and, we can nicely ask the ask the DE compositor to set through the sunshine *Do* and *Undo* actions.
-
-- KDE Plasma:
-
- 1. Use `kscreen-doctor -o` to determine available outputs and resolutions.
- 2. Set sunshine *DO* `kscreen-doctor output.X1.mode.Y1` to the desired client streaming resolution.
- 3. Set sunshine *UNDO* `kscreen-doctor output.X2.mode.Y2` back to the original resolution.
+*Note:* Although we cannot change the resolution through sunshine and, we can nicely ask the ask the DE compositor to set through the sunshine *Do* and *Undo* actions. Refer to the sunshine documentation section: [Changing Resolution and Refresh Rate](https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/guides/app_examples.html#changing-resolution-and-refresh-rate).
 
 ##### Finding the display names
 

--- a/wiki/Buddy-configuration.md
+++ b/wiki/Buddy-configuration.md
@@ -41,7 +41,9 @@ Note: in the Buddy's configuration the screen is referred to as a display due to
 
 Resolution change not supported yet as the [API](https://wayland.app/protocols/wlr-output-management-unstable-v1) is not mature enough and the compositor support is lacking.
 
-*Note:* Although we cannot change the resolution through sunshine and, we can nicely ask the ask the DE compositor to set through the sunshine *Do* and *Undo* actions. Refer to the sunshine documentation section: [Changing Resolution and Refresh Rate](https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/guides/app_examples.html#changing-resolution-and-refresh-rate).
+*Note:* Although we cannot change the resolution directly with sunshine, we can nicely ask the ask the Wayland compositor to set the resolution using sunshine's **Do** and **Undo** actions.
+
+Refer to the sunshine documentation section: [Changing Resolution and Refresh Rate](https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/guides/app_examples.html#changing-resolution-and-refresh-rate).
 
 ##### Finding the display names
 

--- a/wiki/Buddy-configuration.md
+++ b/wiki/Buddy-configuration.md
@@ -49,6 +49,14 @@ Resolution change not supported yet as the [API](https://wayland.app/protocols/w
  2. Set sunshine *DO* `kscreen-doctor output.X1.mode.Y1` to the desired client streaming resolution.
  3. Set sunshine *UNDO* `kscreen-doctor output.X2.mode.Y2` back to the original resolution.
 
+#### Linux Idle
+
+If a game is paused or input is delayed within the idle time limit, power savings can put the monitor to sleep or suspend the system. This can cause issues when trying to resume a game at a later time. You can use systemd-inhibit in order to enforce the system will stay awake, while MoonDeckStream is active. Prepend the following to the *Command* in the Sunshine MoonDeckStream configuration.
+
+```
+systemd-inhibit --what=idle:sleep --who=MoonDeckStream --why="Gaming Session" MoonDeckStream
+```
+
 ##### Finding the display names
 
 You can enable the debug mode to check what displays are available as they are printed when trying to change resolution.

--- a/wiki/Buddy-configuration.md
+++ b/wiki/Buddy-configuration.md
@@ -49,14 +49,6 @@ Resolution change not supported yet as the [API](https://wayland.app/protocols/w
  2. Set sunshine *DO* `kscreen-doctor output.X1.mode.Y1` to the desired client streaming resolution.
  3. Set sunshine *UNDO* `kscreen-doctor output.X2.mode.Y2` back to the original resolution.
 
-#### Linux Inhibit Sleep and Idle
-
-If a game is paused or input is delayed within the idle time limit, power savings can put the monitor to sleep or suspend the system. This can cause issues when trying to resume a game at a later time. You can use systemd-inhibit in order to enforce the system will stay awake, while MoonDeckStream is active. Prepend the following to the *Command* in the Sunshine MoonDeckStream configuration.
-
-```
-systemd-inhibit --what=idle:sleep --who=MoonDeckStream --why="Gaming Session" MoonDeckStream
-```
-
 ##### Finding the display names
 
 You can enable the debug mode to check what displays are available as they are printed when trying to change resolution.

--- a/wiki/Buddy-configuration.md
+++ b/wiki/Buddy-configuration.md
@@ -41,6 +41,14 @@ Note: in the Buddy's configuration the screen is referred to as a display due to
 
 Resolution change not supported yet as the [API](https://wayland.app/protocols/wlr-output-management-unstable-v1) is not mature enough and the compositor support is lacking.
 
+*Note:* Although we cannot change the resolution through sunshine and, we can nicely ask the ask the DE compositor to set through the sunshine *Do* and *Undo* actions.
+
+- KDE Plasma:
+
+ 1. Use `kscreen-doctor -o` to determine available outputs and resolutions.
+ 2. Set sunshine *DO* `kscreen-doctor output.X1.mode.Y1` to the desired client streaming resolution.
+ 3. Set sunshine *UNDO* `kscreen-doctor output.X2.mode.Y2` back to the original resolution.
+
 ##### Finding the display names
 
 You can enable the debug mode to check what displays are available as they are printed when trying to change resolution.
@@ -109,4 +117,4 @@ In case you're using flatpak:
 exec flatpak run com.valvesoftware.Steam "$@"
 ```
 3. `chmod +x <file>`
-4. Use the new file as Steam binary. 
+4. Use the new file as Steam binary.

--- a/wiki/Sunshine-setup.md
+++ b/wiki/Sunshine-setup.md
@@ -44,7 +44,7 @@ namespace Sunshine
             keybd_event(VK_ALT, 0, KEYEVENTF_EXTENDEDKEY, 0);
             keybd_event(VK_LWIN, 0, KEYEVENTF_EXTENDEDKEY, 0);
             keybd_event(VK_B, 0, KEYEVENTF_EXTENDEDKEY, 0);
-            
+
             // Release the keyboard shortcut
             keybd_event(VK_B, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
             keybd_event(VK_LWIN, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);


### PR DESCRIPTION
1. Add some additional configuration info on how to adjust stream resolution using the kwin compositor.
2. Add a mention on how to inhibit the system sleep and idle, while a stream session is running. (Note: this may be a better fit as a feature within MoonDeckStream)